### PR TITLE
Use public class for reflection - fixes bb compatibility

### DIFF
--- a/src/overtone/at_at.clj
+++ b/src/overtone/at_at.clj
@@ -181,9 +181,10 @@
       (loop [jobs jobs]
         (doseq [job jobs]
           (when (and @(:scheduled? job)
-                      (or
-                       (.isCancelled ^java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask (:job job))
-                       (.isDone ^java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask (:job job))))
+                     (let [^java.util.concurrent.Future job (:job job)]
+                       (or
+                        (.isCancelled job)
+                        (.isDone job))))
                (reset! (:scheduled? job) false)))
         (when-let [jobs (filter (fn [j] @(:scheduled? j)) jobs)]
           (Thread/sleep 500)
@@ -345,7 +346,7 @@
           pool-info (:pool-info job-info)
           pool      (:thread-pool pool-info) ; NOTE - unused
           jobs-ref  (:jobs-ref pool-info)]
-      (.cancel ^java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask job cancel-immediately?)
+      (.cancel ^java.util.concurrent.Future job cancel-immediately?)
       (reset! (:scheduled? job-info) false)
       (dosync
        (let [job (get @jobs-ref id)]

--- a/src/overtone/at_at.clj
+++ b/src/overtone/at_at.clj
@@ -181,10 +181,10 @@
       (loop [jobs jobs]
         (doseq [job jobs]
           (when (and @(:scheduled? job)
-                     (let [^java.util.concurrent.Future job (:job job)]
+                     (let [job (:job job)]
                        (or
-                        (.isCancelled job)
-                        (.isDone job))))
+                        (future-cancelled? job)
+                        (future-done? job))))
                (reset! (:scheduled? job) false)))
         (when-let [jobs (filter (fn [j] @(:scheduled? j)) jobs)]
           (Thread/sleep 500)


### PR DESCRIPTION
This PR fixes babashka compatibility by using the public interface as the type hint, rather than a specific type that is really just an implementation detail.